### PR TITLE
Allow date and time for picker

### DIFF
--- a/lib/slack_valid_block_kit/builder/elements.rb
+++ b/lib/slack_valid_block_kit/builder/elements.rb
@@ -202,7 +202,13 @@ module SlackValidBlockKit
         hash = { type: 'timepicker' }
         hash[:action_id] = action_id
         hash[:placeholder] = placeholder unless placeholder.nil?
-        hash[:initial_time] = initial_time unless initial_time.nil?
+        unless initial_time.nil?
+          if initial_time.is_a?(Time)
+            hash[:initial_time] = initial_time.strftime("%H:%M")
+          else
+            hash[:initial_time] = initial_time
+          end
+        end
         hash[:confirm] = confirm unless confirm.nil?
         hash[:focus_on_load] = focus_on_load unless focus_on_load.nil?
         hash

--- a/lib/slack_valid_block_kit/builder/elements.rb
+++ b/lib/slack_valid_block_kit/builder/elements.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module SlackValidBlockKit
   module Builder
     module Elements
@@ -27,7 +29,15 @@ module SlackValidBlockKit
         hash = { type: 'datepicker' }
         hash[:action_id] = action_id
         hash[:placeholder] = placeholder unless placeholder.nil?
-        hash[:initial_date] = initial_date unless initial_date.nil?
+        unless initial_date.nil?
+          if initial_date.is_a?(Date)
+            hash[:initial_date] = initial_date.to_s
+          elsif initial_date.is_a?(Time)
+            hash[:initial_date] = initial_date.to_date.to_s
+          else
+            hash[:initial_date] = initial_date
+          end
+        end
         hash[:confirm] = confirm unless confirm.nil?
         hash[:focus_on_load] = focus_on_load unless focus_on_load.nil?
         hash

--- a/test/builder/date_picker_test.rb
+++ b/test/builder/date_picker_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+module Builder
+  class DatePickerTest < Minitest::Test
+    def test_accept_date_class
+      datepicker = ::SlackValidBlockKit::Builder::Runner.new.datepicker(action_id: "sample", initial_date: Date.new(2022, 1, 2))
+      assert_equal "2022-01-02", datepicker[:initial_date]
+    end
+
+    def test_accept_time_class
+      datepicker = ::SlackValidBlockKit::Builder::Runner.new.datepicker(action_id: "sample", initial_date: Time.new(2022, 1, 2, 22, 4, 5))
+      assert_equal "2022-01-02", datepicker[:initial_date]
+    end
+  end
+end

--- a/test/builder/datepicker_test.rb
+++ b/test/builder/datepicker_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 module Builder
-  class DatePickerTest < Minitest::Test
+  class DatepickerTest < Minitest::Test
     def test_accept_date_class
       datepicker = ::SlackValidBlockKit::Builder::Runner.new.datepicker(action_id: "sample", initial_date: Date.new(2022, 1, 2))
       assert_equal "2022-01-02", datepicker[:initial_date]

--- a/test/builder/timepicker_test.rb
+++ b/test/builder/timepicker_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+module Builder
+  class TimepickerTest < Minitest::Test
+    def test_accept_time_class
+      timepicker = ::SlackValidBlockKit::Builder::Runner.new.timepicker(action_id: "sample", initial_time: Time.new(2022, 1, 2, 22, 4, 5))
+      assert_equal "22:04", timepicker[:initial_time]
+    end
+  end
+end


### PR DESCRIPTION
# What?
We allow values of date and time for date or time picker.

# Why?
Both picker treats date and time, so we want to set Date or Time class.

# How?
We convert input values to a specific format string in the Builder.

# Anything else?
In this PR, we do not  change validation.
